### PR TITLE
APM-1710 Retry on 429 Functionality for the APISessionClient

### DIFF
--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -29,6 +29,30 @@ class APISessionClient:
         url = os.path.join(self.base_uri, url)
         return url
 
+    def _request(
+        self,
+        method: str,
+        url: StrOrURL,
+        *,
+        allow_retries: bool = False,
+        max_retries: int = 5,
+        allow_redirects: bool = True,
+        **kwargs: Any
+    ) -> "aoihttp._RequestContextManager":
+        uri = self._full_url(url)
+        if allow_retries:
+            resp = self._retry_requests(
+                lambda: self.session.request(
+                    method, uri, allow_redirects=allow_redirects, **kwargs
+                ),
+                max_retries=max_retries
+            )
+        else:
+            resp = self.session.request(
+                method, uri, allow_redirects=allow_redirects, **kwargs
+            )
+        return resp
+
     async def _retry_requests(self, make_request, max_retries):
         retry_codes = {429, 503}
         for retry_number in range(max_retries):
@@ -49,19 +73,14 @@ class APISessionClient:
         allow_redirects: bool = True,
         **kwargs: Any
     ) -> "aoihttp._RequestContextManager":
-        uri = self._full_url(url)
-        if allow_retries:
-            resp = self._retry_requests(
-                lambda: self.session.get(
-                    uri, allow_redirects=allow_redirects, **kwargs
-                ),
-                max_retries=max_retries
-            )
-        else:
-            resp = self.session.get(
-                uri, allow_redirects=allow_redirects, **kwargs
-            )
-        return resp
+        return self._request(
+            method="GET",
+            url=url,
+            allow_retries=allow_retries,
+            max_retries=max_retries,
+            allow_redirects=allow_redirects,
+            **kwargs
+        )
 
     def post(
         self,
@@ -72,19 +91,14 @@ class APISessionClient:
         allow_redirects: bool = True,
         **kwargs: Any
     ) -> "aoihttp._RequestContextManager":
-        uri = self._full_url(url)
-        if allow_retries:
-            resp = self._retry_requests(
-                lambda: self.session.post(
-                    uri, allow_redirects=allow_redirects, **kwargs
-                ),
-                max_retries=max_retries
-            )
-        else:
-            resp = self.session.post(
-                uri, allow_redirects=allow_redirects, **kwargs
-            )
-        return resp
+        return self._request(
+            method="POST",
+            url=url,
+            allow_retries=allow_retries,
+            max_retries=max_retries,
+            allow_redirects=allow_redirects,
+            **kwargs
+        )
 
     def put(
         self,
@@ -95,19 +109,14 @@ class APISessionClient:
         allow_redirects: bool = True,
         **kwargs: Any
     ) -> "aoihttp._RequestContextManager":
-        uri = self._full_url(url)
-        if allow_retries:
-            resp = self._retry_requests(
-                lambda: self.session.put(
-                    uri, allow_redirects=allow_redirects, **kwargs
-                ),
-                max_retries=max_retries
-            )
-        else:
-            resp = self.session.put(
-                uri, allow_redirects=allow_redirects, **kwargs
-            )
-        return resp
+        return self._request(
+            method="PUT",
+            url=url,
+            allow_retries=allow_retries,
+            max_retries=max_retries,
+            allow_redirects=allow_redirects,
+            **kwargs
+        )
 
     def delete(
         self,
@@ -118,19 +127,14 @@ class APISessionClient:
         allow_redirects: bool = True,
         **kwargs: Any
     ) -> "aoihttp._RequestContextManager":
-        uri = self._full_url(url)
-        if allow_retries:
-            resp = self._retry_requests(
-                lambda: self.session.delete(
-                    uri, allow_redirects=allow_redirects, **kwargs
-                ),
-                max_retries=max_retries
-            )
-        else:
-            resp = self.session.delete(
-                uri, allow_redirects=allow_redirects, **kwargs
-            )
-        return resp
+        return self._request(
+            method="DELETE",
+            url=url,
+            allow_retries=allow_retries,
+            max_retries=max_retries,
+            allow_redirects=allow_redirects,
+            **kwargs
+        )
 
     async def close(self):
         await self.session.close()

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -29,39 +29,49 @@ class APISessionClient:
         url = os.path.join(self.base_uri, url)
         return url
 
-    def _retry_429s(self, make_request):
-        fib_times = [0,1,1,2,3,5,8,13,21]
+    async def _retry_429s(self, make_request):
+        fib_times = [0, 1, 1, 2, 3, 5, 8, 13, 21]
         fib_index = 0
+
         while True:
-            get_resp = make_request()
-            if get_resp.status == 429:
+            resp = await make_request()
+
+            if resp.status == 429:
                 time.sleep(fib_times[fib_index])
                 fib_index += 1
                 if fib_index == len(fib_times)-1:
-                    return "Time out Error" # Replace with error exeption
+                    return "Time out Error"  # Replace with error exeption
                 continue
-            return get_resp
 
-    def get(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+            return resp
+
+    async def get(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
+            return await self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            print(self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
-            return self.session.get(uri, allow_redirects=allow_redirects, **kwargs)
-        
+            return await self.session.get(uri, allow_redirects=allow_redirects, **kwargs)        
 
-    def post(self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    async def post(self, url: StrOrURL, *,  allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
-        return self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
+        if allow_retries:
+            return await self._retry_429s(lambda: self.session.post(uri, allow_redirects=allow_redirects, **kwargs))
+        else:
+            return await self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
 
-    def put(self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    async def put(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
-        return self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
+        if allow_retries:
+            return await self._retry_429s(lambda: self.session.put(uri, allow_redirects=allow_redirects, **kwargs))
+        else:
+            return await self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
 
-    def delete(self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    async def delete(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
-        return self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
+        if allow_retries:
+            return await self._retry_429s(lambda: self.session.delete(uri, allow_redirects=allow_redirects, **kwargs))
+        else:
+            return await self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
 
     async def close(self):
         await self.session.close()

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -61,8 +61,7 @@ class APISessionClient:
                 await asyncio.sleep(2**retry_number - 1)
                 continue
             return resp
-        else:
-            raise TimeoutError("Maxium retry limit hit.")
+        raise TimeoutError("Maxium retry limit hit.")
 
     def get(
         self,

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -38,7 +38,7 @@ class APISessionClient:
                 continue
             return resp
         else:
-            raise TimeoutError("Time out on request retries")
+            raise TimeoutError("Maxium retry limit hit.")
 
     def get(
         self,

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -1,15 +1,15 @@
 import os
+import asyncio
 from types import TracebackType
 from typing import Optional, Type, Any
 from urllib.parse import urlparse
-import asyncio
 
 import aiohttp
 from aiohttp.typedefs import StrOrURL
 
 
 class APISessionClient:
-    """ wrapper to configuration of a base url for aiohttp session client """
+    """Wrapper to configuration of a base url for aiohttp session client"""
 
     def __init__(self, base_uri, **kwargs):
         self.base_uri = base_uri
@@ -33,23 +33,23 @@ class APISessionClient:
         self,
         method: str,
         url: StrOrURL,
-        *,
+        *args,
         allow_retries: bool = False,
         max_retries: int = 5,
         allow_redirects: bool = True,
         **kwargs: Any
-    ) -> "aoihttp._RequestContextManager":
+    ) -> "aiohttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
             resp = self._retry_requests(
                 lambda: self.session.request(
-                    method, uri, allow_redirects=allow_redirects, **kwargs
+                    method, uri, *args, allow_redirects=allow_redirects, **kwargs
                 ),
                 max_retries=max_retries
             )
         else:
             resp = self.session.request(
-                method, uri, allow_redirects=allow_redirects, **kwargs
+                method, uri, *args, allow_redirects=allow_redirects, **kwargs
             )
         return resp
 
@@ -61,79 +61,19 @@ class APISessionClient:
                 await asyncio.sleep(2**retry_number - 1)
                 continue
             return resp
-        raise TimeoutError("Maxium retry limit hit.")
+        raise TimeoutError("Maximum retry limit hit.")
 
-    def get(
-        self,
-        url: StrOrURL,
-        *,
-        allow_retries: bool = False,
-        max_retries: int = 5,
-        allow_redirects: bool = True,
-        **kwargs: Any
-    ) -> "aoihttp._RequestContextManager":
-        return self._request(
-            method="GET",
-            url=url,
-            allow_retries=allow_retries,
-            max_retries=max_retries,
-            allow_redirects=allow_redirects,
-            **kwargs
-        )
+    def get(self, *args, **kwargs):
+        return self._request('GET', *args, **kwargs)
 
-    def post(
-        self,
-        url: StrOrURL,
-        *,
-        allow_retries: bool = False,
-        max_retries: int = 5,
-        allow_redirects: bool = True,
-        **kwargs: Any
-    ) -> "aoihttp._RequestContextManager":
-        return self._request(
-            method="POST",
-            url=url,
-            allow_retries=allow_retries,
-            max_retries=max_retries,
-            allow_redirects=allow_redirects,
-            **kwargs
-        )
+    def post(self, *args, **kwargs):
+        return self._request('POST', *args, **kwargs)
 
-    def put(
-        self,
-        url: StrOrURL,
-        *,
-        allow_retries: bool = False,
-        max_retries: int = 5,
-        allow_redirects: bool = True,
-        **kwargs: Any
-    ) -> "aoihttp._RequestContextManager":
-        return self._request(
-            method="PUT",
-            url=url,
-            allow_retries=allow_retries,
-            max_retries=max_retries,
-            allow_redirects=allow_redirects,
-            **kwargs
-        )
+    def put(self, *args, **kwargs):
+        return self._request('PUT', *args, **kwargs)
 
-    def delete(
-        self,
-        url: StrOrURL,
-        *,
-        allow_retries: bool = False,
-        max_retries: int = 5,
-        allow_redirects: bool = True,
-        **kwargs: Any
-    ) -> "aoihttp._RequestContextManager":
-        return self._request(
-            method="DELETE",
-            url=url,
-            allow_retries=allow_retries,
-            max_retries=max_retries,
-            allow_redirects=allow_redirects,
-            **kwargs
-        )
+    def delete(self, *args, **kwargs):
+        return self._request('DELETE', *args, **kwargs)
 
     async def close(self):
         await self.session.close()

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -2,7 +2,7 @@ import os
 from types import TracebackType
 from typing import Optional, Type, Any
 from urllib.parse import urlparse
-import time
+import asyncio
 
 import aiohttp
 from aiohttp.typedefs import StrOrURL
@@ -54,11 +54,11 @@ class APISessionClient:
         return resp
 
     async def _retry_requests(self, make_request, max_retries):
-        retry_codes = {429, 503}
+        retry_codes = {429, 503, 409}
         for retry_number in range(max_retries):
             resp = await make_request()
             if resp.status in retry_codes:
-                time.sleep(2**retry_number - 1)
+                await asyncio.sleep(2**retry_number - 1)
                 continue
             return resp
         else:

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -30,48 +30,50 @@ class APISessionClient:
         return url
 
     async def _retry_429s(self, make_request):
-        fib_times = [0, 1, 1, 2, 3, 5, 8, 13, 21]
-        fib_index = 0
+        try:
+            fib_times = [0, 1, 1, 2, 3, 5, 8, 13, 21]
+            fib_index = 0
+            while True:
+                resp = await make_request()
 
-        while True:
-            resp = await make_request()
+                if resp.status == 429:
+                    time.sleep(fib_times[fib_index])
+                    fib_index += 1
+                    if fib_index == len(fib_times)-1:
+                        raise TimeoutError('Time out on 429 retries')
+                    continue
 
-            if resp.status == 429:
-                time.sleep(fib_times[fib_index])
-                fib_index += 1
-                if fib_index == len(fib_times)-1:
-                    return "Time out Error"  # Replace with error exeption
-                continue
+                return resp
+        except TimeoutError:
+            raise
 
-            return resp
-
-    async def get(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def get(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return await self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
+            return self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return await self.session.get(uri, allow_redirects=allow_redirects, **kwargs)        
+            return self.session.get(uri, allow_redirects=allow_redirects, **kwargs)        
 
-    async def post(self, url: StrOrURL, *,  allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def post(self, url: StrOrURL, *,  allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return await self._retry_429s(lambda: self.session.post(uri, allow_redirects=allow_redirects, **kwargs))
+            return self._retry_429s(lambda: self.session.post(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return await self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
+            return self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
 
-    async def put(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def put(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return await self._retry_429s(lambda: self.session.put(uri, allow_redirects=allow_redirects, **kwargs))
+            return self._retry_429s(lambda: self.session.put(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return await self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
+            return self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
 
-    async def delete(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def delete(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return await self._retry_429s(lambda: self.session.delete(uri, allow_redirects=allow_redirects, **kwargs))
+            return self._retry_429s(lambda: self.session.delete(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return await self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
+            return self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
 
     async def close(self):
         await self.session.close()

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -19,7 +19,7 @@ class APISessionClient:
         return self
 
     def _full_url(self, url: StrOrURL) -> StrOrURL:
-        if not isinstance(url, str) :
+        if not isinstance(url, str):
             return url
 
         parsed = urlparse(url)
@@ -39,44 +39,96 @@ class APISessionClient:
                 if resp.status == 429:
                     time.sleep(fib_times[fib_index])
                     fib_index += 1
-                    if fib_index == len(fib_times)-1:
+                    if fib_index == len(fib_times) - 1:
                         raise TimeoutError
                     continue
 
                 return resp
         except TimeoutError as e:
-            raise TimeoutError('Time out on 429 retries') from e
+            raise TimeoutError("Time out on 429 retries") from e
 
-    def get(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def get(
+        self,
+        url: StrOrURL,
+        *,
+        allow_retries: bool = False,
+        allow_redirects: bool = True,
+        **kwargs: Any
+    ) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            resp = self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(
+                lambda: self.session.get(
+                    uri, allow_redirects=allow_redirects, **kwargs
+                )
+            )
         else:
-            resp = self.session.get(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.get(
+                uri, allow_redirects=allow_redirects, **kwargs
+            )
         return resp
 
-    def post(self, url: StrOrURL, *,  allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def post(
+        self,
+        url: StrOrURL,
+        *,
+        allow_retries: bool = False,
+        allow_redirects: bool = True,
+        **kwargs: Any
+    ) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            resp = self._retry_429s(lambda: self.session.post(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(
+                lambda: self.session.post(
+                    uri, allow_redirects=allow_redirects, **kwargs
+                )
+            )
         else:
-            resp = self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.post(
+                uri, allow_redirects=allow_redirects, **kwargs
+            )
         return resp
 
-    def put(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def put(
+        self,
+        url: StrOrURL,
+        *,
+        allow_retries: bool = False,
+        allow_redirects: bool = True,
+        **kwargs: Any
+    ) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            resp = self._retry_429s(lambda: self.session.put(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(
+                lambda: self.session.put(
+                    uri, allow_redirects=allow_redirects, **kwargs
+                )
+            )
         else:
-            resp = self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.put(
+                uri, allow_redirects=allow_redirects, **kwargs
+            )
         return resp
 
-    def delete(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
+    def delete(
+        self,
+        url: StrOrURL,
+        *,
+        allow_retries: bool = False,
+        allow_redirects: bool = True,
+        **kwargs: Any
+    ) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            resp = self._retry_429s(lambda: self.session.delete(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(
+                lambda: self.session.delete(
+                    uri, allow_redirects=allow_redirects, **kwargs
+                )
+            )
         else:
-            resp = self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.delete(
+                uri, allow_redirects=allow_redirects, **kwargs
+            )
         return resp
 
     async def close(self):
@@ -84,9 +136,9 @@ class APISessionClient:
         return self
 
     async def __aexit__(
-            self,
-            exc_type: Optional[Type[BaseException]],
-            exc_val: Optional[BaseException],
-            exc_tb: Optional[TracebackType],
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
     ) -> None:
         await self.close()

--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -40,40 +40,44 @@ class APISessionClient:
                     time.sleep(fib_times[fib_index])
                     fib_index += 1
                     if fib_index == len(fib_times)-1:
-                        raise TimeoutError('Time out on 429 retries')
+                        raise TimeoutError
                     continue
 
                 return resp
-        except TimeoutError:
-            raise
+        except TimeoutError as e:
+            raise TimeoutError('Time out on 429 retries') from e
 
     def get(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(lambda: self.session.get(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return self.session.get(uri, allow_redirects=allow_redirects, **kwargs)        
+            resp = self.session.get(uri, allow_redirects=allow_redirects, **kwargs)
+        return resp
 
     def post(self, url: StrOrURL, *,  allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return self._retry_429s(lambda: self.session.post(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(lambda: self.session.post(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.post(uri, allow_redirects=allow_redirects, **kwargs)
+        return resp
 
     def put(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return self._retry_429s(lambda: self.session.put(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(lambda: self.session.put(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.put(uri, allow_redirects=allow_redirects, **kwargs)
+        return resp
 
     def delete(self, url: StrOrURL, *, allow_retries: bool = False, allow_redirects: bool = True, **kwargs: Any) -> "aoihttp._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            return self._retry_429s(lambda: self.session.delete(uri, allow_redirects=allow_redirects, **kwargs))
+            resp = self._retry_429s(lambda: self.session.delete(uri, allow_redirects=allow_redirects, **kwargs))
         else:
-            return self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
+            resp = self.session.delete(uri, allow_redirects=allow_redirects, **kwargs)
+        return resp
 
     async def close(self):
         await self.session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ norecursedirs = ".venv .eggs build dist"
 testpaths = [
     "tests"
 ]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "serial",
+]
 
 [tool.dephell.main]
 from = {format = "poetry", path = "pyproject.toml"}

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -106,7 +106,7 @@ async def test_retry_request_varying_responses(status_codes, max_retries, expect
     async with APISessionClient("https://httpbin.org") as session:
         mock_status_list = map(mock_response, status_codes)
         requester = MockRequest(mock_status_list)
-        resp = await session._retry_requests(requester, max_retries)
+        resp = await session._retry_requests(requester, max_retries) # pylint: disable=W0212
         assert resp.status == expected_response
 
 
@@ -117,6 +117,6 @@ async def test_retry_request_varying_error():
         mock_status_list = map(mock_response, [429, 429, 503])
         requester = MockRequest(mock_status_list)
         with pytest.raises(TimeoutError) as excinfo:
-            await session._retry_requests(requester, max_retries=3)
+            await session._retry_requests(requester, max_retries=3) # pylint: disable=W0212
             error = excinfo.value
             assert error == "Maxium retry limit hit."

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -81,8 +81,6 @@ class MockRequest:
         self.iterator = iter(iterable)
 
     async def __call__(self):
-        # async def f():
-        #     return next(self.iterator)
         return next(self.iterator)
 
 

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -74,7 +74,7 @@ async def test_503_without_allow_retries():
 async def test_429_with_allow_retries():
     async with APISessionClient("https://httpbin.org") as session:
         with pytest.raises(TimeoutError) as excinfo:
-            await session.get("status/429", allow_retries=True)
+            await session.get("status/429", allow_retries=True, max_retries=3)
 
         error = excinfo.value
         assert "Time out on request retries" in str(error)
@@ -85,7 +85,15 @@ async def test_429_with_allow_retries():
 async def test_503_with_allow_retries():
     async with APISessionClient("https://httpbin.org") as session:
         with pytest.raises(TimeoutError) as excinfo:
-            await session.get("status/503", allow_retries=True)
+            await session.get("status/503", allow_retries=True, max_retries=3)
 
         error = excinfo.value
         assert "Time out on request retries" in str(error)
+
+# Test other methods
+# How to simulate behaviour of different responses coming back? - override the request function to send the requests back (Only if have extra time as behaviour covered)
+
+# Parametrizing tests
+# Try exponential back off rather than fib
+# Python generators - how to generate next n in sequence
+# Do that with number of retries

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -2,8 +2,6 @@ import json
 
 import pytest
 
-import requests
-
 from api_test_utils.api_session_client import APISessionClient
 
 

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -49,7 +49,7 @@ async def test_explicit_uri_http_bin_post(api_client: APISessionClient):
 
 
 @pytest.mark.asyncio
-async def test_200_with_allow_retries(api_client: APISessionClient):
+async def test_200_with_allow_retries():
     async with APISessionClient("https://httpbin.org") as session:
         async with await session.get("get", allow_retries=True) as resp:
             assert resp.status == 200
@@ -57,7 +57,7 @@ async def test_200_with_allow_retries(api_client: APISessionClient):
 
 # This test intentially takes at least 54 seconds to execute and might not be right for deploys
 @pytest.mark.asyncio
-async def test_429_with_allow_retries(api_client: APISessionClient):
+async def test_429_with_allow_retries():
     async with APISessionClient("https://httpbin.org") as session:
         with pytest.raises(TimeoutError) as excinfo:
             await session.get("status/429", allow_retries=True)

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -64,9 +64,9 @@ async def test_get_status_code_retries(endpoint, should_retry, expected):
 @pytest.mark.slow
 @pytest.mark.asyncio
 @pytest.mark.parametrize("endpoint, should_retry, expected_error", [
-    ("status/429", True, "Maxium retry limit hit."),
-    ("status/503", True, "Maxium retry limit hit."),
-    ("status/409", True, "Maxium retry limit hit.")
+    ("status/429", True, "Maximum retry limit hit."),
+    ("status/503", True, "Maximum retry limit hit."),
+    ("status/409", True, "Maximum retry limit hit.")
 ])
 async def test_max_retries_limit(endpoint, should_retry, expected_error):
     async with APISessionClient("https://httpbin.org") as session:
@@ -119,4 +119,4 @@ async def test_retry_request_varying_error():
         with pytest.raises(TimeoutError) as excinfo:
             await session._retry_requests(requester, max_retries=3) # pylint: disable=W0212
             error = excinfo.value
-            assert error == "Maxium retry limit hit."
+            assert error == "Maximum retry limit hit."

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -52,7 +52,8 @@ async def test_explicit_uri_http_bin_post(api_client: APISessionClient):
 @pytest.mark.parametrize("endpoint, should_retry, expected", [
     ("get", True, 200),
     ("status/429", False, 429),
-    ("status/503", False, 503)
+    ("status/503", False, 503),
+    ("status/409", False, 409)
 ])
 async def test_get_status_code_retries(endpoint, should_retry, expected):
     async with APISessionClient("https://httpbin.org") as session:
@@ -64,7 +65,8 @@ async def test_get_status_code_retries(endpoint, should_retry, expected):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("endpoint, should_retry, expected_error", [
     ("status/429", True, "Maxium retry limit hit."),
-    ("status/503", True, "Maxium retry limit hit.")
+    ("status/503", True, "Maxium retry limit hit."),
+    ("status/409", True, "Maxium retry limit hit.")
 ])
 async def test_max_retries_limit(endpoint, should_retry, expected_error):
     async with APISessionClient("https://httpbin.org") as session:
@@ -94,7 +96,7 @@ class MockStatus:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("status_codes, max_retries, expected_response", [
     ([429, 429, 200, 200], 4, 200),
-    ([503, 429, 503, 200], 4, 200),
+    ([503, 429, 409, 200], 4, 200),
 ])
 async def test_retry_request_varying_responses(status_codes, max_retries, expected_response):
     async with APISessionClient("https://httpbin.org") as session:

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -46,3 +46,26 @@ async def test_explicit_uri_http_bin_post(api_client: APISessionClient):
         assert body['headers'].get('Host') == 'httpbin.org'
         assert body['headers'].get('Content-Type') == 'application/json'
         assert body['data'] == json.dumps(data)
+
+
+@pytest.mark.asyncio
+async def test_200_with_allow_retries(api_client: APISessionClient):
+    async with APISessionClient("https://httpbin.org") as session:
+        async with await session.get("get", allow_retries=True) as resp:
+            assert resp.status == 200
+
+
+# This test intentially takes at least 54 seconds to execute and might not be right for deploys
+@pytest.mark.asyncio
+async def test_429_with_allow_retries(api_client: APISessionClient):
+    async with APISessionClient("https://httpbin.org") as session:
+        with pytest.raises(TimeoutError) as excinfo:
+            await session.get("status/429", allow_retries=True)
+
+        error = excinfo.value
+        assert "Time out on 429 retries" in str(error)
+
+# Test other methods
+# Test other status'?
+# Test Functionality of _retry_429s in here?
+# How to simulate behaviour of different responses coming back?


### PR DESCRIPTION
Adding funcionality to the APISessionClient for conditionally retrying 429s on all requests.