### PR TITLE
apm-1946: retried requests should be wrapped in a context manager for…

### DIFF
--- a/api_test_utils/api_session_client.py
+++ b/api_test_utils/api_session_client.py
@@ -5,6 +5,7 @@ from typing import Optional, Type, Any
 from urllib.parse import urlparse
 
 import aiohttp
+from aiohttp.client import _RequestContextManager
 from aiohttp.typedefs import StrOrURL
 
 
@@ -38,15 +39,15 @@ class APISessionClient:
         max_retries: int = 5,
         allow_redirects: bool = True,
         **kwargs: Any
-    ) -> "aiohttp._RequestContextManager":
+    ) -> "aiohttp.client._RequestContextManager":
         uri = self._full_url(url)
         if allow_retries:
-            resp = self._retry_requests(
+            resp = _RequestContextManager(self._retry_requests(
                 lambda: self.session.request(
                     method, uri, *args, allow_redirects=allow_redirects, **kwargs
                 ),
                 max_retries=max_retries
-            )
+            ))
         else:
             resp = self.session.request(
                 method, uri, *args, allow_redirects=allow_redirects, **kwargs

--- a/tests/session_client_tests.py
+++ b/tests/session_client_tests.py
@@ -57,7 +57,7 @@ async def test_explicit_uri_http_bin_post(api_client: APISessionClient):
 ])
 async def test_get_status_code_retries(endpoint, should_retry, expected):
     async with APISessionClient("https://httpbin.org") as session:
-        async with await session.get(endpoint, allow_retries=should_retry) as resp:
+        async with session.get(endpoint, allow_retries=should_retry) as resp:
             assert resp.status == expected
 
 


### PR DESCRIPTION
… consistent interface  +minor